### PR TITLE
Add build script and docker build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,15 @@
    ```bash
    npm run setup:env:dev
    ```
-3. Запустіть систему:
+3. Побудуйте Docker образи:
+   ```bash
+   npm run build
+   ```
+4. Запустіть систему:
    ```bash
    npm run start:dev
    ```
-4. Відкрийте браузер за адресою `http://localhost:3000`
+5. Відкрийте браузер за адресою `http://localhost:3000`
 
 ### Налаштування середовищ
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "setup:env": "./config/setup-env.sh",
     "setup:env:dev": "./config/setup-env.sh development",
     "setup:env:test": "./config/setup-env.sh testing",
-    "setup:env:prod": "./config/setup-env.sh production"
+    "setup:env:prod": "./config/setup-env.sh production",
+    "build": "docker-compose build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add `build` script using `docker-compose build`
- mention building containers in README

## Testing
- `npm run build` *(fails: `docker-compose` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed0299b1c832ba8d877b257a83fcb